### PR TITLE
Fixing: Aftermath is unable to display shader source

### DIFF
--- a/D3D12HelloNsightAftermath/D3D12HelloNsightAftermath.vcxproj
+++ b/D3D12HelloNsightAftermath/D3D12HelloNsightAftermath.vcxproj
@@ -148,6 +148,8 @@
     <FxCompile Include="VertexShader.hlsl">
       <ShaderType>Vertex</ShaderType>
       <EntryPointName>VSMain</EntryPointName>
+	  <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">-Qembed_debug %(AdditionalOptions)</AdditionalOptions>
+	  <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">-Qembed_debug %(AdditionalOptions)</AdditionalOptions>
     </FxCompile>
     <FxCompile Include="PixelShader.hlsl">
       <ShaderType>Pixel</ShaderType>
@@ -159,8 +161,6 @@
   <ItemGroup>
     <None Include="Shader.hlsli">
       <ExcludedFromBuild>true</ExcludedFromBuild>
-	  <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">-Qembed_debug %(AdditionalOptions)</AdditionalOptions>
-	  <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">-Qembed_debug %(AdditionalOptions)</AdditionalOptions>
     </None>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/D3D12HelloNsightAftermath/D3D12HelloNsightAftermath.vcxproj
+++ b/D3D12HelloNsightAftermath/D3D12HelloNsightAftermath.vcxproj
@@ -152,11 +152,15 @@
     <FxCompile Include="PixelShader.hlsl">
       <ShaderType>Pixel</ShaderType>
       <EntryPointName>PSMain</EntryPointName>
+	  <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">-Qembed_debug %(AdditionalOptions)</AdditionalOptions>
+	  <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">-Qembed_debug %(AdditionalOptions)</AdditionalOptions>
     </FxCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Shader.hlsli">
       <ExcludedFromBuild>true</ExcludedFromBuild>
+	  <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">-Qembed_debug %(AdditionalOptions)</AdditionalOptions>
+	  <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">-Qembed_debug %(AdditionalOptions)</AdditionalOptions>
     </None>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />


### PR DESCRIPTION
Fixing the Aftermath error happening while opening the Shader Source view, despite having all the paths set properly. Only IL view is available.

"No shader debug info file found. Check that the Shader Binaries and Separate Shader Debug Information paths are configured correctly in the [Search Path Settings ](https://github.com/NVIDIA/nsight-aftermath-samples/compare/Search%20Paths). Refer to the [User Guide ](https://docs.nvidia.com/nsight-graphics/UserGuide/index.html#gcd_inspector_config) for more details."

Adding -Qembed_debug compilation argument on the HLSL files so that CSO files have all the debug information required.
The real reason is most likely that PDB files are not recognized properly. I found no explanation to that. Even deleting them does not change much. 