### PR TITLE
Headless mode and only compute shader with extensions

### DIFF
--- a/VkHelloNsightAftermath/CMakeLists.txt
+++ b/VkHelloNsightAftermath/CMakeLists.txt
@@ -244,6 +244,16 @@ add_custom_command(COMMENT "Compiling cube fragment shader"
                    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE_DIR:VkHelloNsightAftermath>/cube.frag.spirv ${CMAKE_BINARY_DIR}/cube.frag.spirv
                    MAIN_DEPENDENCY ${PROJECT_SOURCE_DIR}/cube.frag
                    DEPENDS ${PROJECT_SOURCE_DIR}/cube.frag ${GLSLANG_VALIDATOR})
+add_custom_command(COMMENT "Compiling cube compute shader"
+                   OUTPUT cube.comp.spirv
+                   COMMAND ${GLSLANG_VALIDATOR} -V -g -o $<TARGET_FILE_DIR:VkHelloNsightAftermath>/cube.comp.full.spirv
+                           ${PROJECT_SOURCE_DIR}/cube.comp
+                   COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE_DIR:VkHelloNsightAftermath>/cube.comp.full.spirv ${CMAKE_BINARY_DIR}/cube.comp.full.spirv
+                   COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE_DIR:VkHelloNsightAftermath>/cube.comp.full.spirv $<TARGET_FILE_DIR:VkHelloNsightAftermath>/cube.comp.spirv
+                   COMMAND ${CMAKE_COMMAND} -E chdir $<TARGET_FILE_DIR:VkHelloNsightAftermath> ${SPIRV_REMAP} --map all --strip-all --input cube.comp.spirv --output ./
+                   COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE_DIR:VkHelloNsightAftermath>/cube.comp.spirv ${CMAKE_BINARY_DIR}/cube.comp.spirv
+                   MAIN_DEPENDENCY ${PROJECT_SOURCE_DIR}/cube.comp
+                   DEPENDS ${PROJECT_SOURCE_DIR}/cube.comp ${GLSLANG_VALIDATOR} ${SPIRV_REMAP})
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
@@ -265,8 +275,10 @@ if(NOT WIN32)
                        NsightAftermathShaderDatabase.cpp
                        cube.vert
                        cube.frag
+                       cube.comp
                        cube.vert.spirv
-                       cube.frag.spirv)
+                       cube.frag.spirv
+                       cube.comp.spirv)
         target_link_libraries(VkHelloNsightAftermath PRIVATE Vulkan::Vulkan NsightAftermath::NsightAftermath dl)
         target_compile_options(VkHelloNsightAftermath PRIVATE -DVULKAN_HPP_DISABLE_IMPLICIT_RESULT_VALUE_CAST)
 endif()
@@ -284,8 +296,10 @@ else()
                    NsightAftermathShaderDatabase.cpp
                    cube.vert
                    cube.frag
+                   cube.comp
                    cube.vert.spirv
-                   cube.frag.spirv)
+                   cube.frag.spirv
+                   cube.comp.spirv)
     target_link_libraries(VkHelloNsightAftermath PRIVATE Vulkan::Vulkan NsightAftermath::NsightAftermath)
     target_compile_options(VkHelloNsightAftermath PRIVATE -DVULKAN_HPP_DISABLE_IMPLICIT_RESULT_VALUE_CAST)
 

--- a/VkHelloNsightAftermath/NsightAftermathGpuCrashTracker.cpp
+++ b/VkHelloNsightAftermath/NsightAftermathGpuCrashTracker.cpp
@@ -69,7 +69,7 @@ void GpuCrashTracker::Initialize(bool applicationUsesStrippedShaders)
     AFTERMATH_CHECK_ERROR(GFSDK_Aftermath_EnableGpuCrashDumps(
         GFSDK_Aftermath_Version_API,
         GFSDK_Aftermath_GpuCrashDumpWatchedApiFlags_Vulkan,
-        GFSDK_Aftermath_GpuCrashDumpFeatureFlags_DeferDebugInfoCallbacks, // Let the Nsight Aftermath library cache shader debug information.
+        GFSDK_Aftermath_GpuCrashDumpFeatureFlags_Default, // Let the Nsight Aftermath library cache shader debug information.
         GpuCrashDumpCallback,                                             // Register callback for GPU crash dumps.
         ShaderDebugInfoCallback,                                          // Register callback for shader debug information.
         CrashDumpDescriptionCallback,                                     // Register callback for GPU crash dump description.
@@ -318,6 +318,7 @@ void GpuCrashTracker::GpuCrashDumpCallback(
     const uint32_t gpuCrashDumpSize,
     void* pUserData)
 {
+    fprintf(stdout, "Calling gpu crash dump callback!\n");
     GpuCrashTracker* pGpuCrashTracker = reinterpret_cast<GpuCrashTracker*>(pUserData);
     pGpuCrashTracker->OnCrashDump(pGpuCrashDump, gpuCrashDumpSize);
 }

--- a/VkHelloNsightAftermath/cube.comp
+++ b/VkHelloNsightAftermath/cube.comp
@@ -1,0 +1,42 @@
+#version 450
+
+layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+
+layout(std140, binding = 0) restrict buffer buf {
+        mat4 MVP;
+        vec4 position[12*3];
+        vec4 attr[12*3];
+        vec4 offset;
+} ubuf;
+
+#define ENDLESSLOOP_CS 0
+#define SHAREDMEMOUTOFBOUNDS_CS 1
+#define OUTOFBOUNDS_CS 0
+
+#define SHARED_MEMORY_SIZE 64
+
+// Shared memory for the workgroup (doesn't require bindings)
+shared float sharedData[SHARED_MEMORY_SIZE];
+
+void main() {
+    vec4 inverted = vec4(1.0, 0.0, 0.0, 1.0);
+    vec4 position_temp = ubuf.position[2];
+
+#if OUTOFBOUNDS_CS
+    // Intentional out of bounds access for testing
+    uint bad_idx = 31324;  // Maximum uint value
+    ubuf.position[bad_idx] = vec4(1.0,0.0,0.0,1.0);
+#endif
+
+#if SHAREDMEMOUTOFBOUNDS_CS
+    uint idx_2 = 1;
+    uint bad_idx_2 = idx_2 + 31324;
+    sharedData[bad_idx_2] = 2.0;
+#endif
+
+#if ENDLESSLOOP_CS
+   while (true)
+   {
+   }
+#endif
+}

--- a/VkHelloNsightAftermath/cube.vert
+++ b/VkHelloNsightAftermath/cube.vert
@@ -33,7 +33,7 @@ layout (location = 0) out vec4 texcoord;
 layout (location = 1) out vec3 frag_pos;
 layout (location = 2) out float alpha;
 
-#define ENDLESSLOOP_VS 1
+#define ENDLESSLOOP_VS 0
 
 void main() 
 {


### PR DESCRIPTION
These are the changes I made in order to try to reproduce the issues we have been seeing with aftermath in the cloud. 

Keep in mind, i'm not a rendering engineer at all so I got by as far as I could with claude, so dont be alarmed if some things don't make sense or are messy.

How to reproduce:
I built the binary with debug symbols 

cmake -DCMAKE_BUILD_TYPE=Debug .. 
make

and then ran `/VkHelloNsightAftermath --headless` i added a new flag that turns off everything related to the viewport. i also removed everything related to the graphics pipeline and only create a compute pipeline that runs one compute shader. in that shader (cube.comp), i have a few different failure cases which I expect to cause a gpu crash

#define ENDLESSLOOP_CS 0
#define SHAREDMEMOUTOFBOUNDS_CS 1
#define OUTOFBOUNDS_CS 0

so with a gui enabled, `sudo systemctl isolate graphical.target`, it fails and `Calling gpu crash dump callback!` gets called (a debug print line i added)

but, if you run the same thing with `sudo systemctl isolate multi-user.target`, it instead hangs. 

My reproduction rate with this is that sometimes its flaky, for some reason i've noticed that sometimes it works (the crash dump callback is called) but when i start to enable extensions, it begins to hang. i've added all of the extensions that our project currently uses, as our leading theory is that there's some interaction with the vk extensions and with aftermath.

Please let me know if you have any issues reproducing, or other questions you might need about our setup.



Aftermath version: NVIDIA_Nsight_Aftermath_SDK_2024.1.0.24075/lib/x64/libGFSDK_Aftermath_Lib.x64.so (for some reason other aftermath versions would have versioning issues)

└─(17:58:10 on user/kevin/headless_and_comp ✭)──> nvidia-smi                                                                                                                                                                            ──(Thu,Sep04)─┘
Thu Sep  4 17:58:46 2025       
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 570.181                Driver Version: 570.181        CUDA Version: 12.8     |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA GeForce RTX 4090        Off |   00000000:01:00.0  On |                  Off |
|  0%   40C    P5             46W /  450W |    1009MiB /  24564MiB |     25%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+
                                                                                         
+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|    0   N/A  N/A          499398      G   /usr/lib/xorg/Xorg                      384MiB |
|    0   N/A  N/A          499693      G   /usr/bin/gnome-shell                    192MiB |
|    0   N/A  N/A          500494      G   ...slack/212/usr/lib/slack/slack        102MiB |
|    0   N/A  N/A          500586      G   ...ess --variations-seed-version        120MiB |
|    0   N/A  N/A          514618      G   ...ersion=20250904-050038.050000         63MiB |
|    0   N/A  N/A          514898      G   /usr/bin/nautilus                        19MiB |
